### PR TITLE
BUG: Fix groupby sorting on ordered Categoricals (GH25871)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -347,7 +347,7 @@ Groupby/Resample/Rolling
 - Bug in :func:`pandas.core.groupby.GroupBy.agg` when applying a aggregation function to timezone aware data (:issue:`23683`)
 - Bug in :func:`pandas.core.groupby.GroupBy.first` and :func:`pandas.core.groupby.GroupBy.last` where timezone information would be dropped (:issue:`21603`)
 - Ensured that ordering of outputs in ``groupby`` aggregation functions is consistent across all versions of Python (:issue:`25692`)
-
+- Ensured that result group order is correct when grouping on an ordered Categorical and specifying ``observed=True`` (:issue:`25871`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -302,6 +302,8 @@ class Grouping(object):
                 if observed:
                     codes = algorithms.unique1d(self.grouper.codes)
                     codes = codes[codes != -1]
+                    if sort or self.grouper.ordered:
+                        codes = np.sort(codes)
                 else:
                     codes = np.arange(len(categories))
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -453,6 +453,28 @@ def test_dataframe_categorical_with_nan(observed):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("observed", [True, False])
+@pytest.mark.parametrize("sort",     [True, False])
+def test_dataframe_categorical_ordered_observed(observed, sort):
+    # GH 25871
+    cat = pd.Categorical([3, 1, 2, 1, 3, 2], categories=[1, 2, 3, 4], ordered=True)
+    val = pd.Series([1.5, 0.5, 1.0, 0.5, 1.5, 1.0])
+    df  = pd.DataFrame({'cat': cat, 'val': val})
+    result = df.groupby('cat', observed=observed, sort=sort)['val'].agg('sum')
+    
+    # For ordered Categoricals, sort must have no influence on the result (they always sort)
+    if observed:
+        expected = pd.Series(data=[1.0, 2.0, 3.0], 
+                             index=pd.CategoricalIndex([1, 2, 3], categories=[1, 2, 3, 4], ordered=True, name='cat', dtype='category'), 
+                             dtype='float64', name='val')
+    else:
+        expected = pd.Series(data=[1.0, 2.0, 3.0, 0.0], 
+                             index=pd.CategoricalIndex([1, 2, 3, 4], categories=[1, 2, 3, 4], ordered=True, name='cat', dtype='category'), 
+                             dtype='float64', name='val')
+    
+    tm.assert_series_equal(result, expected)
+
+
 def test_datetime():
     # GH9049: ensure backward compatibility
     levels = pd.date_range('2014-01-01', periods=4)


### PR DESCRIPTION
As documented in #25871, groupby() on an ordered Categorical messes up category order when 'observed=True' is specified. 
Specifically, group labels will be ordered by first occurrence (as for an unordered Categorical), but grouped aggregation results will retain the Categorical's order.
The fix is a modified subset of #25173, which fixes a related case, but has not been merged yet.

- [x] closes #25871
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
